### PR TITLE
multimedia/ffmpeg010: Updated SlackBuild.

### DIFF
--- a/multimedia/ffmpeg010/ffmpeg010.SlackBuild
+++ b/multimedia/ffmpeg010/ffmpeg010.SlackBuild
@@ -121,7 +121,6 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-x11grab \
   --enable-avfilter \
   --enable-gnutls \
-  --enable-libcdio \
   --arch=$ARCH \
   $openjpeg \
   $libdc1394 \


### PR DESCRIPTION
Disabled libcdio support to fix build on -current with libcdio-0.93.

Signed-off-by: David Spencer <baildon.research@googlemail.com>