### PR TITLE
Specified hard dependencies for compilation

### DIFF
--- a/audio/clementine/README
+++ b/audio/clementine/README
@@ -15,3 +15,14 @@ gst-libav (for m4a support)
 sparsehash (for various online services)
 libspotify and libqca (for Spotify support) (not on SBo)
 vlc
+
+Hard dependencies (requirements)
+libechonest
+protobuf
+cryptopp
+
+NOTE:
+If compilation fails even if you have cryptopp installed, make sure to update your SlackBuild files
+to the latest release.
+Cryptopp does not include a pkgconfig file in its distribution and previous SlackBuild files didn't
+include one either.


### PR DESCRIPTION
Specified libechonest, cryptopp and protobuf as required dependencies. Without them compilation will fail.

Also added a warning about using the latest cryptopp SlackBuild files due to its lack of a pkgconfig.