### PR TITLE
RSSOwl: hunspell has been updated in current.

### DIFF
--- a/network/RSSOwl/RSSOwl.SlackBuild
+++ b/network/RSSOwl/RSSOwl.SlackBuild
@@ -73,7 +73,7 @@ ln -s /usr/lib${LIBDIRSUFFIX}/RSSOwl/RSSOwl $PKG/usr/bin/RSSOwl
 mkdir -p $PKG/usr/lib${LIBDIRSUFFIX}/$PRGNAM
 cp -av * $PKG/usr/lib${LIBDIRSUFFIX}/$PRGNAM
 
-sed -i 's,libhunspell-1.2.so.0,libhunspell-1.3.so.0,g' $PKG/usr/lib${LIBDIRSUFFIX}/$PRGNAM/xulrunner/libxul.so
+sed -i 's,libhunspell-1.2.so.0,libhunspell-1.6.so.0,g' $PKG/usr/lib${LIBDIRSUFFIX}/$PRGNAM/xulrunner/libxul.so
 
 mkdir -p $PKG/usr/share/pixmaps
 cp -av icon.xpm $PKG/usr/share/pixmaps/$PRGNAM.xpm


### PR DESCRIPTION
Opening feeds fails without this change.