### PR TITLE
Improve configure flags

### DIFF
--- a/python/python3/python3.SlackBuild
+++ b/python/python3/python3.SlackBuild
@@ -99,6 +99,7 @@ find -L . \
   --with-threads \
   --enable-ipv6 \
   --enable-shared \
+  --enable-profiling \
   --with-system-expat \
   --with-system-ffi \
   --build=$ARCH-slackware-linux


### PR DESCRIPTION
Need to --enable-profiling to make the profile and cProfile from the standard library. They are used to debug the code.
In python 2.7.x from the default installation it was not necessary and was compiled by default.
Maybe you could also --enable-optimizations, but I don't know if its the case for a default make.