### PR TITLE
Updated awesome.SlackBuild CFLAG for -current to fix error

### DIFF
--- a/desktop/awesome/awesome.SlackBuild
+++ b/desktop/awesome/awesome.SlackBuild
@@ -72,7 +72,7 @@ find -L . \
 mkdir -p build
 cd build
   cmake \
-    -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS -ldl" \
+    -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS -ldl -w -Wl,--allow-multiple-definition" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DAWESOME_MAN_PATH=/usr/man \
     -DAWESOME_DOC_PATH=/usr/doc/$PRGNAM-$VERSION \


### PR DESCRIPTION
Fixes 'multiple definition of  .* first defined here' error on current.