### PR TITLE
Add python3 support to dulwich.Slackbuild

### DIFF
--- a/python/dulwich/dulwich.SlackBuild
+++ b/python/dulwich/dulwich.SlackBuild
@@ -57,6 +57,11 @@ find -L . \
 
 python setup.py install --root=$PKG
 
+# Python 3 support.
+if $(python3 -c 'import sys' 2>/dev/null); then
+    python3 setup.py install --root=$PKG
+fi
+
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 


### PR DESCRIPTION
dulwich is a dependency of hg-git, a mercurial plugin. Mercurial is python3-only in -current, so its plugins need python3 support.

dulwich is also a dependency of Kallithea, which is still installed as python2-only. I don't know Kallithea, so I don't propose to drop python2 support from dulwich.