### PR TITLE
Switch hg-git.Slackbuild to python3

### DIFF
--- a/python/hg-git/hg-git.SlackBuild
+++ b/python/hg-git/hg-git.SlackBuild
@@ -55,7 +55,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-python setup.py install --root=$PKG
+python3 setup.py install --root=$PKG
 
 mkdir -p $PKG/etc/mercurial/hgrc.d
 cat > $PKG/etc/mercurial/hgrc.d/hggit.rc.new << EOF


### PR DESCRIPTION
hg-git is a plugin for mercurial, which is compiled for python3 only in -current, so this PR switches over to python3 for hg-git as well.