### PR TITLE
Fix for GCC10 to bspwm.SlackBuild

### DIFF
--- a/desktop/bspwm/bspwm.SlackBuild
+++ b/desktop/bspwm/bspwm.SlackBuild
@@ -73,7 +73,7 @@ find -L . \
 sed -i "s|share/man|man|" Makefile
 sed -i "s|share/doc/bspwm|doc/bspwm-$VERSION|" Makefile
 
-CFLAGS="$SLKCFLAGS" \
+CFLAGS="$SLKCFLAGS -fcommon" \
 CXXFLAGS="$SLKCFLAGS" \
 make PREFIX=/usr
 make PREFIX=/usr DESTDIR=$PKG install


### PR DESCRIPTION
Didn't see a bspwm branch, so pushing to master. Fixes build failure for -current due to GCC 10 issue.