### PR TITLE
Fix to ignore pointer casts in system libraries

### DIFF
--- a/audio/ardour/README
+++ b/audio/ardour/README
@@ -2,4 +2,4 @@ Ardour is an application to fit the needs of musicians under Linux.
 It is designed to be a fully functional professional audio application,
 that uses the professional sound server jack for sound i/o.
 
-cppunit, lua and suil are optional dependencies.
+soundtouch, libwebsockets, cppunit, lua and suil are optional dependencies.

--- a/audio/ardour/ardour.SlackBuild
+++ b/audio/ardour/ardour.SlackBuild
@@ -77,7 +77,7 @@ find -L . \
 patch -p1 < $CWD/vendor_qm-dsp.patch
 
 CFLAGS="$SLKCFLAGS" \
-CXXFLAGS="$SLKCFLAGS -std=c++11" \
+CXXFLAGS="$SLKCFLAGS -std=c++11 -fpermissive" \
 ./waf configure \
   --prefix=/usr \
   --libdir=/usr/lib${LIBDIRSUFFIX} \


### PR DESCRIPTION
Ardour fails to build because casts in C system libraries (glib2?) that won't compile in C++.  Added compiler flag to demote error to warning.  Also, noted two optional dependencies (available in Slackbuilds.org).  Additionally, this script will compile Ardour 6.6.0 if you upgrade the source tarball.  I could not find a direct download link.  See redirects on [ardour.org](https://community.ardour.org/srctar) or [github](https://github.com/Ardour/ardour/archive/refs/tags/6.6.tar.gz).