### PR TITLE
Remove Slackware 14.2 dependency note

### DIFF
--- a/audio/guitarix/README
+++ b/audio/guitarix/README
@@ -14,10 +14,6 @@ meterbridge is an optional runtime dependency.
 Starting with version 0.35.4, guitarix's 'Online presets' feature no
 longer requires webkitgtk. See README.online for more information.
 
-Note: This is the last version of guitarix that will compile on
-Slackware 14.2, due to 0.40 and up requiring gtk+3 >= 3.20 (we only
-have 3.18). Sorry, folks.
-
 This package uses POSIX filesystem capabilities to execute with
 elevated privileges (required for realtime audio processing). This
 may be considered a security/stability risk. Please read


### PR DESCRIPTION
Stale stanza in README about Slackware 14.2 is not valid for Slackware 15 beta.