### PR TITLE
youtube-dl: Fix download link

### DIFF
--- a/network/youtube-dl/youtube-dl.info
+++ b/network/youtube-dl/youtube-dl.info
@@ -1,7 +1,7 @@
 PRGNAM="youtube-dl"
 VERSION="2021.04.26"
 HOMEPAGE="http://www.yt-dl.org/"
-DOWNLOAD="https://www.yt-dl.org/downloads/latest/youtube-dl-2021.04.26.tar.gz"
+DOWNLOAD="https://www.yt-dl.org/downloads/2021.04.26/youtube-dl-2021.04.26.tar.gz"
 MD5SUM="dfc60fbac7e59130c7791e2ebc90801d"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""


### PR DESCRIPTION
The "latest" folder on github does not point to 2021.04.26 any more.