### PR TITLE
Fix for vboxnetflt driver to build with 5.11+ kernel

### DIFF
--- a/system/virtualbox-kernel/VBoxNetFlt-ethtool.patch
+++ b/system/virtualbox-kernel/VBoxNetFlt-ethtool.patch
@@ -1,0 +1,11 @@
+--- VBoxNetFlt-linux.c.fixed	2021-06-18 13:12:36.227183712 +0300
++++ VBoxNetFlt-linux.c	2021-06-18 13:12:56.326183949 +0300
+@@ -51,7 +51,7 @@
+ #include <net/ipv6.h>
+ #include <net/if_inet6.h>
+ #include <net/addrconf.h>
+-
++#include <linux/ethtool.h>
+ #include <VBox/log.h>
+ #include <VBox/err.h>
+ #include <VBox/intnetinline.h>

--- a/system/virtualbox-kernel/virtualbox-kernel.SlackBuild
+++ b/system/virtualbox-kernel/virtualbox-kernel.SlackBuild
@@ -57,6 +57,7 @@ mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
 rm -rf $PRGNAM-$VERSION
 tar xvf $CWD/$PRGNAM-$VERSION.tar.xz
+patch vboxnetflt/linux/VBoxNetFlt-linux.c < $CWD/VBoxNetFlt-ethtool.patch
 cd $PRGNAM-$VERSION
 chown -R root:root .
 find -L . \


### PR DESCRIPTION
Original bug report: https://www.virtualbox.org/ticket/20198