### PR TITLE
Update gedit.SlackBuild

### DIFF
--- a/development/gedit/gedit.SlackBuild
+++ b/development/gedit/gedit.SlackBuild
@@ -90,6 +90,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --localstatedir=/var \
   --mandir=/usr/man \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
+  --disable-spell \
   --disable-scrollkeeper \
   --build=$ARCH-slackware-linux
 


### PR DESCRIPTION
Disable Spellchecker as it requires enchant1 which is no longer available in 15.x (-current). More recent versions would require a bunch of GTK dependencies like gtksourceview4, tepl etc.