### PR TITLE
Fix i686 build by removing target CFLAGS.  Bump version.

### DIFF
--- a/development/avr-gcc/avr-gcc.SlackBuild
+++ b/development/avr-gcc/avr-gcc.SlackBuild
@@ -10,8 +10,8 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=avr-gcc
-VERSION=${VERSION:-10.2.0}
-ISLVERSION=${ISLVERSION:-0.22}
+VERSION=${VERSION:-11.2.0}
+ISLVERSION=${ISLVERSION:-0.24}
 BUILD=${BUILD:-1}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
@@ -57,7 +57,7 @@ mkdir -p $TMP/$PRGNAM $PKG $OUTPUT
 cd $TMP/$PRGNAM
 rm -rf $TMP/$PRGNAM/*
 tar xvf $CWD/gcc-$VERSION.tar.xz
-tar xvf $CWD/isl-$ISLVERSION.tar.bz2
+tar xvf $CWD/isl-$ISLVERSION.tar.xz
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
@@ -69,8 +69,8 @@ ln -s ../isl-$ISLVERSION isl
 mkdir ../avr-gcc-build-$VERSION
 cd ../avr-gcc-build-$VERSION
 
-export CFLAGS_FOR_TARGET="$SLKCFLAGS"
-export CXXFLAGS_FOR_TARGET="$SLKCFLAGS"
+export CFLAGS_FOR_TARGET="-O2 -pipe"
+export CXXFLAGS_FOR_TARGET="-O2 -pipe"
 
 ../gcc-$VERSION/configure \
   --prefix=/usr \

--- a/development/avr-gcc/avr-gcc.info
+++ b/development/avr-gcc/avr-gcc.info
@@ -1,10 +1,10 @@
 PRGNAM="avr-gcc"
-VERSION="10.2.0"
+VERSION="11.2.0"
 HOMEPAGE="http://www.gnu.org/software/gcc/"
-DOWNLOAD="ftp://ftp.gnu.org/pub/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz \
-          http://isl.gforge.inria.fr/isl-0.22.tar.bz2"
-MD5SUM="e9fd9b1789155ad09bcf3ae747596b50 \
-        4e6b2a1dd20b2ac011730a24580ff7a9"
+DOWNLOAD="ftp://ftp.gnu.org/pub/gnu/gcc/gcc-11.2.0/gcc-11.2.0.tar.xz \
+          http://isl.gforge.inria.fr/isl-0.24.tar.xz"
+MD5SUM="31c86f2ced76acac66992eeedce2fce2 \
+        fae030f604a9537adc2502990a8ab4d1"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="avr-binutils"


### PR DESCRIPTION
Build fails on i586/i686 arch because script is sending host CFLAGS (-march -mtune) to target (a cross-compiler).  Fix and bump to match Slackware 15 tool versions.

Emailed maintainer about this bug on Feb 3 and have not had reply.

Note: ISL source website has been very unresponsive.  Could convert to use the Slackware 15 sources for GCC and ISL now that 15.0 has been released.