### PR TITLE
Update picom.SlackBuild

### DIFF
--- a/desktop/picom/picom.SlackBuild
+++ b/desktop/picom/picom.SlackBuild
@@ -81,7 +81,7 @@ find -L . \
 
 CFLAGS="$SLKCFLAGS" \
 CXXFLAGS="$SLKCFLAGS" \
-meson build . -D build_docs=true -D b_ndebug=true --prefix=/usr
+meson build . -D with_docs=true -D b_ndebug=true --prefix=/usr
 DESTDIR=$PKG "${NINJA:=ninja}" -C build install
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \


### PR DESCRIPTION
`build_docs` has been renamed to `with_docs`:
https://github.com/yshui/picom/commit/3f2a6718dfb84110862ef3b51b2c961898f21bfd