### PR TITLE
Update Flask.info

### DIFF
--- a/python/Flask/Flask.info
+++ b/python/Flask/Flask.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/f/flask/Flask-2.1.2.tar
 MD5SUM="93f1832e5be704ef6ff2a4124579cd85"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="werkzeug python3-itsdangerous click python-importlib_metadata"
+REQUIRES="werkzeug python3-itsdangerous click"
 MAINTAINER="fourtysixandtwo"
 EMAIL="fourtysixandtwo@sliderr.net"


### PR DESCRIPTION
removed python-importlib_metadata its already in the installation