### PR TITLE
thinkfan: Fix BIN path to thinkfan in rc.thinkfan

### DIFF
--- a/system/thinkfan/rc.thinkfan
+++ b/system/thinkfan/rc.thinkfan
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 NAME=thinkfan
-BIN=/usr/bin/$NAME
+BIN=/usr/sbin/$NAME
 CONFIG=/etc/thinkfan.conf
 ARGS="-q -c $CONFIG"
 PIDFILE=/var/run/$NAME.pid


### PR DESCRIPTION
This PR fixes the `BIN` variable to the correct path to thinkfan.