### PR TITLE
pdal: Fix a type mismatch error

### DIFF
--- a/gis/pdal/pdal-Geometry.cpp.patch
+++ b/gis/pdal/pdal-Geometry.cpp.patch
@@ -1,0 +1,20 @@
+--- pdal/Geometry.cpp.orig	2023-04-13 12:07:49.000000000 -0600
++++ pdal/Geometry.cpp	2023-06-10 08:58:52.245292599 -0600
+@@ -153,7 +153,7 @@
+ 
+ bool Geometry::srsValid() const
+ {
+-    OGRSpatialReference *srs = m_geom->getSpatialReference();
++    const OGRSpatialReference *srs = m_geom->getSpatialReference();
+     return srs && srs->GetRoot();
+ }
+ 
+@@ -172,7 +172,7 @@
+         return StatusWithReason(-2,
+             "Geometry::transform() failed.  NULL target SRS.");
+ 
+-    OGRSpatialReference *inSrs = m_geom->getSpatialReference();
++    const OGRSpatialReference *inSrs = m_geom->getSpatialReference();
+     SrsTransform transform(*inSrs, OGRSpatialReference(out.getWKT().data()));
+     if (m_geom->transform(transform.get()) != OGRERR_NONE)
+         return StatusWithReason(-1, "Geometry::transform() failed.");

--- a/gis/pdal/pdal.SlackBuild
+++ b/gis/pdal/pdal.SlackBuild
@@ -96,6 +96,7 @@ cd $TMP
 rm -rf $SRCNAM-$VERSION
 tar xvf $CWD/$SRCNAM-$VERSION.tar.gz
 cd $SRCNAM-$VERSION
+patch -p0 < $CWD/pdal-Geometry.cpp.patch
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \


### PR DESCRIPTION
This PR fixes an invalid conversion from `const` to non-`const`:
```
Geometry.cpp: In member function ‘bool pdal::Geometry::srsValid() const’:
Geometry.cpp:156:59: error: invalid conversion from ‘const OGRSpatialReference*’ to ‘OGRSpatialReference*’ [-fpermissive]
  156 |     OGRSpatialReference *srs = m_geom->getSpatialReference();
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
      |                                                           |
      |                                                           const OGRSpatialReference*
Geometry.cpp: In member function ‘pdal::Utils::StatusWithReason pdal::Geometry::transform(pdal::SpatialReference)’:
Geometry.cpp:175:61: error: invalid conversion from ‘const OGRSpatialReference*’ to ‘OGRSpatialReference*’ [-fpermissive]
  175 |     OGRSpatialReference *inSrs = m_geom->getSpatialReference();
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
      |                                                             |
      |                                                             const OGRSpatialReference*
Geometry.cpp: In member function ‘std::string pdal::Geometry::json(double) const’:
Geometry.cpp:291:12: warning: ‘void OGRFree(void*)’ is deprecated [-Wdeprecated-declarations]
  291 |     OGRFree(json);
      |     ~~~~~~~^~~~~~
In file included from /usr/include/ogr_api.h:45,
                 from Geometry.cpp:37:
/usr/include/ogr_core.h:358:14: note: declared here
  358 | void CPL_DLL OGRFree(void *) CPL_WARN_DEPRECATED("Use CPLFree instead.");
      |              ^~~~~~~
```