### PR TITLE
system/vinterm: Add missing include for GCC compatibility.

### DIFF
--- a/system/vinterm/includes.diff
+++ b/system/vinterm/includes.diff
@@ -1,0 +1,10 @@
+--- vinterm-0.5.0/terminal/pty.h	2013-08-20 01:34:06.000000000 +0900
++++ vinterm-0.5.0.patched/terminal/pty.h	2023-07-01 09:41:53.057899502 +0900
+@@ -3,6 +3,7 @@
+ 
+ #include <string>
+ #include <ostream>
++#include <cstdint>
+ using namespace std;
+ 
+ class Options;

--- a/system/vinterm/vinterm.SlackBuild
+++ b/system/vinterm/vinterm.SlackBuild
@@ -15,7 +15,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=vinterm
 VERSION=${VERSION:-0.5.0}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -66,6 +66,8 @@ sed -i -e "s,-Os,$SLKCFLAGS," -e "s,usr/lib,usr/lib$LIBDIRSUFFIX," config.mk
 
 # GRR. "make install" respects DESTDIR... except for the icons and .desktop.
 patch -p1 < $CWD/fix_destdir.diff
+# Add an include statement for GCC compatibility.
+patch -p1 < $CWD/includes.diff
 
 export TERMINFO=$PKG/usr/share/terminfo
 mkdir -p $TERMINFO


### PR DESCRIPTION
In a similar vein to Issue #201, vinterm needs an additional include statement to build with -current's GCC.