### PR TITLE
development/bazel: gcc-13 compatibility.

### DIFF
--- a/development/bazel/abseil-missing-stdint.patch
+++ b/development/bazel/abseil-missing-stdint.patch
@@ -1,0 +1,10 @@
+--- abseil-cpp.orig/absl/strings/internal/str_format/extension.h
++++ abseil-cpp/absl/strings/internal/str_format/extension.h
+@@ -26,6 +26,7 @@
+ #include "absl/base/port.h"
+ #include "absl/meta/type_traits.h"
+ #include "absl/strings/internal/str_format/output.h"
++#include <cstdint>
+ #include "absl/strings/string_view.h"
+ 
+ namespace absl {

--- a/development/bazel/apply-abseil-stdint.patch
+++ b/development/bazel/apply-abseil-stdint.patch
@@ -1,0 +1,13 @@
+--- distdir_deps.bzl.orig	2023-09-05 16:10:13.000617742 +0900
++++ distdir_deps.bzl	2023-09-05 16:10:42.471484181 +0900
+@@ -163,6 +163,10 @@
+     },
+     "com_google_absl": {
+         "archive": "20211102.0.tar.gz",
++	"patch_args": ["-p1"],
++        "patches": [
++            "//:abseil-missing-stdint.patch"
++        ],
+         "sha256": "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
+         "urls": [
+             "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz",

--- a/development/bazel/bazel.SlackBuild
+++ b/development/bazel/bazel.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=bazel
 VERSION=${VERSION:-5.4.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -75,6 +75,10 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+# Missing include.
+patch -p0 < $CWD/apply-abseil-stdint.patch
+cp $CWD/abseil-missing-stdint.patch .
 
 # Export environmental variables
 # Please change JAVA_HOME if not using zulu-openjdk11


### PR DESCRIPTION
This is another missing include statement for `gcc-13`; the patch itself comes from openSUSE.