### PR TITLE
fcitx5-mozc: gcc-13 compatibility.

### DIFF
--- a/misc/fcitx5-mozc/0013-mozc-includes.patch
+++ b/misc/fcitx5-mozc/0013-mozc-includes.patch
@@ -1,0 +1,20 @@
+--- third_party/abseil-cpp/absl/strings/internal/str_format/float_conversion.cc	2023-09-05 17:36:23.973250174 +0900
++++ third_party/abseil-cpp/absl/strings/internal/str_format/float_conversion.cc	2023-09-05 17:37:06.585477262 +0900
+@@ -5,6 +5,7 @@
+ #include <algorithm>
+ #include <cassert>
+ #include <cmath>
++#include <cstdint>
+ #include <limits>
+ #include <string>
+ 
+--- third_party/abseil-cpp/absl/strings/internal/str_format/extension.h	2023-09-05 17:45:04.104106229 +0900
++++ third_party/abseil-cpp/absl/strings/internal/str_format/extension.h	2023-09-05 17:45:24.484098612 +0900
+@@ -20,6 +20,7 @@
+ 
+ #include <cstddef>
+ #include <cstring>
++#include <cstdint>
+ #include <ostream>
+ 
+ #include "absl/base/config.h"

--- a/misc/fcitx5-mozc/fcitx5-mozc.SlackBuild
+++ b/misc/fcitx5-mozc/fcitx5-mozc.SlackBuild
@@ -165,6 +165,10 @@ cd src/
 # Build with gcc instead of clang
 echo "... Apply 0012-mozc-build-gcc.patch"
 patch -p1 < $CWD/0012-mozc-build-gcc.patch
+# gcc-13 compatibility
+pwd
+echo "... Apply 0013-mozc-includes.patch"
+patch -p0 < $CWD/0013-mozc-includes.patch
 
 # Fix compatibility with google-glog 0.3.3 (symbol conflict)
 CFLAGS="${CFLAGS} -fvisibility=hidden"


### PR DESCRIPTION
`gcc-13` compatibility patch. I found this and `bazel` installing -current to a new laptop; everything else I built looked OK.