### PR TITLE
development/oneTBB: Use clang and fix warnings.

### DIFF
--- a/development/oneTBB/includes.patch
+++ b/development/oneTBB/includes.patch
@@ -1,0 +1,10 @@
+--- oneTBB-2021.6.0.orig/test/common/utils_assert.h	2023-07-24 20:21:49.362670251 +0900
++++ oneTBB-2021.6.0/test/common/utils_assert.h	2023-07-24 20:22:27.350547548 +0900
+@@ -19,6 +19,7 @@
+ 
+ #include "config.h"
+ #include "utils_report.h"
++#include <cstdlib>
+ 
+ #define REPORT_FATAL_ERROR REPORT
+ 

--- a/development/oneTBB/oneTBB.SlackBuild
+++ b/development/oneTBB/oneTBB.SlackBuild
@@ -77,6 +77,10 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# Missing include
+patch -p1 < $CWD/includes.patch
+# Remove unused variables (upstream 17b7834, 274f68e)
+patch -p1 < $CWD/unused.patch
 
 # enable Python
 if [ "${PYTHON:-no}" == "yes" ];then
@@ -85,6 +89,8 @@ fi
 
 mkdir -p build
 cd build
+CC=/usr/bin/clang \
+CXX=/usr/bin/clang++ \
   cmake \
     -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
     -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \

--- a/development/oneTBB/unused.patch
+++ b/development/oneTBB/unused.patch
@@ -1,0 +1,39 @@
+--- oneTBB-2021.6.0.orig/test/conformance/conformance_flowgraph.h	2023-12-17 14:34:12.234366082 +0900
++++ oneTBB-2021.6.0/test/conformance/conformance_flowgraph.h	2023-12-17 15:27:02.512416476 +0900
+@@ -79,8 +79,9 @@
+ template<typename V>
+ typename std::enable_if<!std::is_default_constructible<V>::value, std::vector<V>>::type get_values( test_push_receiver<V>& rr ) {
+     std::vector<V> messages;
+-    int val = 0;
+-    for(V tmp(0); rr.try_get(tmp); ++val) {
++    V tmp(0);
++
++    while (rr.try_get(tmp)) {
+         messages.push_back(tmp);
+     }
+     return messages;
+@@ -89,8 +90,9 @@
+ template<typename V>
+ typename std::enable_if<std::is_default_constructible<V>::value, std::vector<V>>::type get_values( test_push_receiver<V>& rr ) {
+     std::vector<V> messages;
+-    int val = 0;
+-    for(V tmp; rr.try_get(tmp); ++val) {
++    V tmp;
++
++    while (rr.try_get(tmp)) {
+         messages.push_back(tmp);
+     }
+     return messages;
+--- oneTBB-2021.6.0.orig/test/conformance/conformance_join_node.cpp	2023-12-17 14:34:12.235366077 +0900
++++ oneTBB-2021.6.0/test/conformance/conformance_join_node.cpp	2023-12-17 15:45:20.864114506 +0900
+@@ -28,8 +28,8 @@
+ 
+ std::vector<my_input_tuple> get_values( conformance::test_push_receiver<my_input_tuple>& rr ) {
+     std::vector<my_input_tuple> messages;
+-    int val = 0;
+-    for(my_input_tuple tmp(0, 0.f, input_msg(0)); rr.try_get(tmp); ++val) {
++    my_input_tuple tmp(0, 0.f, input_msg(0));
++    while(rr.try_get(tmp)) {
+         messages.push_back(tmp);
+     }
+     return messages;


### PR DESCRIPTION
This version seems to get along very poorly with `gcc-13.2.0`. I tried patching in commits from upstream to get it to build, but the trail eventually went cold. It needs patches to build with `clang` as well, but they aren't nearly as extensive.

The two patches here would no longer be necessary if the version is ever bumped, and I'm guessing the build could go back to `gcc`.

Both reverse dependencies build (`oneDPL` and `ueberzugpp`).