### PR TITLE
games/higan: Add missing include.

### DIFF
--- a/games/higan/higan.SlackBuild
+++ b/games/higan/higan.SlackBuild
@@ -116,6 +116,8 @@ chown -R root:root .
 # for its support files if they're not found in ~/.local/share/higan.
 patch -p1 -i $CWD/higan-flags.diff
 patch -p1 -i $CWD/higan-paths.diff
+# 20240131 KEC: gcc-13.x compatibility
+patch -p1 -i $CWD/includes.diff
 
 # 20181212 bkw: audio system stuff. Upstream doesn't give us a way to
 # disable these on the make command line, but hacking this file works:

--- a/games/higan/includes.diff
+++ b/games/higan/includes.diff
@@ -1,0 +1,8 @@
+--- higan-106.orig/nall/arithmetic/natural.hpp	2024-01-31 09:12:37.166634947 +0900
++++ higan-106/nall/arithmetic/natural.hpp	2024-01-31 09:12:58.147526383 +0900
+@@ -1,3 +1,5 @@
++#include <stdexcept>
++
+ #define ConcatenateType(Size) uint##Size##_t
+ #define DeclareType(Size) ConcatenateType(Size)
+ 


### PR DESCRIPTION
Add a missing include statement to build with gcc-13.x.