### PR TITLE
games/openttd: icu compatibility patch.

### DIFF
--- a/games/openttd/icu.patch
+++ b/games/openttd/icu.patch
@@ -1,0 +1,33 @@
+https://github.com/OpenTTD/OpenTTD/commit/14fac2ad37bfb9cec56b4f9169d864f6f1c7b96e
+
+From 14fac2ad37bfb9cec56b4f9169d864f6f1c7b96e Mon Sep 17 00:00:00 2001
+From: fundawang <fundawang@yeah.net>
+Date: Tue, 5 Nov 2024 19:12:34 +0800
+Subject: [PATCH] Fix: build with icu >= 76 where icu-i18n and icu-uc become
+ separated (#13048)
+
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 137eb7d0f8ce9..2f0248047506a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -152,7 +152,7 @@ if(NOT OPTION_DEDICATED)
+                 find_package(Fontconfig)
+             endif()
+             find_package(Harfbuzz)
+-            find_package(ICU OPTIONAL_COMPONENTS i18n)
++            find_package(ICU OPTIONAL_COMPONENTS i18n uc)
+         endif()
+     endif()
+ endif()
+@@ -331,6 +331,7 @@ if(NOT OPTION_DEDICATED)
+     link_package(Fontconfig TARGET Fontconfig::Fontconfig)
+     link_package(Harfbuzz TARGET harfbuzz::harfbuzz)
+     link_package(ICU_i18n)
++    link_package(ICU_uc)
+ 
+     if(SDL2_FOUND AND OPENGL_FOUND AND UNIX)
+         # SDL2 dynamically loads OpenGL if needed, so do not link to OpenGL when

--- a/games/openttd/openttd.SlackBuild
+++ b/games/openttd/openttd.SlackBuild
@@ -96,6 +96,9 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# KEC: icu-76.1 compatibility (2025-01-13) (upstream 14fac2a) (via Gentoo)
+patch -p1 < $CWD/icu.patch
+
 mkdir -p build
 cd build
   cmake \


### PR DESCRIPTION
There's an icu-related linking problem right at the end of the build. Found the patch in the Gentoo repository.