### PR TITLE
desktop/flatpak: Fix error in build script.

### DIFF
--- a/desktop/flatpak/flatpak.SlackBuild
+++ b/desktop/flatpak/flatpak.SlackBuild
@@ -29,7 +29,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=flatpak
 VERSION=${VERSION:-1.16.0}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -91,7 +91,7 @@ cd build
     --mandir=/usr/man \
     --prefix=/usr \
     --sysconfdir=/etc \
-    -Dsystem_bubblewrap=true \
+    -Dsystem_bubblewrap=bwrap \
     -Ddocdir=/usr/doc/$PRGNAM-$VERSION \
     -Dstrip=true
   "${NINJA:=ninja}"


### PR DESCRIPTION
The recent update to flatpak (commit dc8fe82) runs `meson` with `-Dsystem_bubblewrap=true`. This unfortunately does not do what you would expect - it configures flatpak to use `/usr/bin/true` as the bubblewrap executable!

This of course breaks things and in particular running any flatpak application fails with an error "Can't open generated ld.so.cache" (see also https://github.com/flatpak/flatpak/issues/6024).

Here's a patch that fixes it to use `bwrap` as the bubblewrap executable.