### PR TITLE
system/brlaser: Fix for cmake >= 4.x.

### DIFF
--- a/system/brlaser/brlaser.SlackBuild
+++ b/system/brlaser/brlaser.SlackBuild
@@ -80,6 +80,7 @@ cd build
   cmake \
     -DCMAKE_CXX_FLAGS_RELEASE:STRING="$SLKCFLAGS" \
     -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DCMAKE_BUILD_TYPE=Release ..
   make
   make install/strip DESTDIR=$PKG


### PR DESCRIPTION
Added flag -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to fix cmake 4 build

Cheers
Michele