### PR TITLE
Fix: Add -Wno-error to CFLAGS when building office/gnucash. 

### DIFF
--- a/office/gnucash/gnucash.SlackBuild
+++ b/office/gnucash/gnucash.SlackBuild
@@ -50,22 +50,22 @@ PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
 if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
+  SLKCFLAGS="-O2 -march=i586 -mtune=i686 -Wno-error"
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
+  SLKCFLAGS="-O2 -march=i686 -mtune=i686 -Wno-error"
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
+  SLKCFLAGS="-O2 -fPIC -Wno-error"
   LIBDIRSUFFIX="64"
 elif [ "$ARCH" = "s390" ]; then
-  SLKCFLAGS="-O2"
+  SLKCFLAGS="-O2 -Wno-error"
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "arm" ]; then
-  SLKCFLAGS="-O2 -march=armv4t"
+  SLKCFLAGS="-O2 -march=armv4t -Wno-error"
   LIBDIRSUFFIX=""
 else
-  SLKCFLAGS="-O2"
+  SLKCFLAGS="-O2 -Wno-error"
   LIBDIRSUFFIX=""
 fi
 


### PR DESCRIPTION
The GCC included in -current converts warnings to errors.  GNUCash produces a deprecation warning related to SAX support, causing the build to fail.  Compiler warnings will not be tretaed as errors allowing the SlackBuild to complete.