### PR TITLE
system/runit: Fix compilation

### DIFF
--- a/system/runit/runit.SlackBuild
+++ b/system/runit/runit.SlackBuild
@@ -8,7 +8,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=runit
 VERSION=${VERSION:-2.1.2}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -57,7 +57,17 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-echo gcc $SLKCFLAGS -Wall > src/conf-cc
+echo gcc $SLKCFLAGS -D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE \
+ -Wall -Wno-incompatible-pointer-types -Wno-misleading-indentation \
+ -std=c89 > src/conf-cc
+
+# Apply fixes
+sed -i '/#include.*/a #include <grp\.h>' src/chkshsgr.c
+sed -i '/#include.*/a #include <grp\.h>' src/chpst.c
+sed -i '0,/#include.*/a #include <unistd\.h>' src/seek_set.c
+sed -i '0,/#include.*/a #include <unistd\.h>' src/prot.c
+sed -i '0,/#include.*/a #include <grp\.h>' src/prot.c
+sed -i '0,/#include.*/a #include <unistd\.h>' src/pathexec_run.c
 
 package/compile
 package/check


### PR DESCRIPTION
Does not compile anymore due to changes in compiler, but with some `sed` commands, you can get it running again.