### PR TITLE
graphics/vimiv-qt: Fix compiliation error (replace setup.py with pyproject.toml)

### DIFF
--- a/graphics/vimiv-qt/build-with-pyproject-toml.patch
+++ b/graphics/vimiv-qt/build-with-pyproject-toml.patch
@@ -1,0 +1,12 @@
+--- a/misc/Makefile
++++ b/misc/Makefile
+@@ -29,7 +29,8 @@
+ 	@printf "make clean: 	        Remove build directories.\n"
+ 
+ install:
+-	python3 setup.py install --root=$(DESTDIR)/ --prefix=$(PREFIX) --record=install_log.txt
++	python3 -m build --no-isolation
++	python3 -m installer -d $(DESTDIR) dist/*.whl
+ 	install -Dm644 misc/vimiv.desktop $(APPDIR)/vimiv.desktop
+ 	install -Dm644 misc/org.karlch.vimiv.qt.metainfo.xml $(METAINFODIR)/org.karlch.vimiv.qt.metainfo.xml
+ 	install -Dm644 LICENSE $(LICENSEDIR)/vimiv/LICENSE

--- a/graphics/vimiv-qt/vimiv-qt.SlackBuild
+++ b/graphics/vimiv-qt/vimiv-qt.SlackBuild
@@ -2,7 +2,7 @@
 
 # Slackware build script for vimiv-qt
 
-# Copyright 2022-2024 Isaac Yu <isaacyu@protonmail.com>
+# Copyright 2022-2025 Isaac Yu <isaacyu@protonmail.com>
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=vimiv-qt
 VERSION=${VERSION:-0.9.0}
-BUILD=${BUILD:-2}
+BUILD=${BUILD:-3}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -46,20 +46,6 @@ fi
 TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
-
-if [ "$ARCH" = "i586" ]; then
-  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "i686" ]; then
-  SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
-elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
-else
-  SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
-fi
 
 set -e
 
@@ -81,6 +67,9 @@ sed -i "s/\$(DATADIR)\\/man/\$(DESTDIR)\\/\$(PREFIX)\\/man/g" misc/Makefile
 
 # Do not install license files to /usr/share/licenses
 sed -i "/LICENSEDIR/d" misc/Makefile
+
+# Fix build error (use pyproject.toml instead of setup.py)
+patch -p1 < $CWD/build-with-pyproject-toml.patch
 
 make -f misc/Makefile DESTDIR=$PKG install
 


### PR DESCRIPTION
I have received the following error when building vimiv-qt on Slackware-current:
```
Copying vimiv.egg-info to /tmp/SBo/package-vimiv-qt/usr/lib64/python3.12/site-packages/vimiv-0.9.0-py3.12.egg-info
running install_scripts
Traceback (most recent call last):
  File "/tmp/SBo/vimiv-qt-0.9.0/setup.py", line 40, in <module>
    setuptools.setup(
  File "/usr/lib/python3.12/site-packages/setuptools/__init__.py", line 115, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 186, in setup
    return run_commands(dist)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
    dist.run_commands()
  File "/usr/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.12/site-packages/setuptools/dist.py", line 1102, in run_command
    super().run_command(command)
  File "/usr/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.12/site-packages/setuptools/_distutils/command/install.py", line 700, in run
    self.run_command(cmd_name)
  File "/usr/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 357, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.12/site-packages/setuptools/dist.py", line 1102, in run_command
    super().run_command(command)
  File "/usr/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.12/site-packages/setuptools/command/install_scripts.py", line 31, in run
    self._install_ep_scripts()
  File "/usr/lib/python3.12/site-packages/setuptools/command/install_scripts.py", line 50, in _install_ep_scripts
    for args in writer.get_args(dist, cmd.as_header()):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/SBo/vimiv-qt-0.9.0/fastentrypoints.py", line 63, in get_args
    spec = str(dist.as_requirement())
               ^^^^^^^^^^^^^^^^^^^
AttributeError: 'PathDistribution' object has no attribute 'as_requirement'
make: *** [misc/Makefile:30: install] Error 1
```

My SlackBuild runs `make install` using `misc/MakeFile` as the makefile.
`misc/MakeFile` runs `python3 setup.py install`, resulting in the error above.

The way I am fixing this is by replacing the Makefile's setup.py with pyproject.toml.
I am not making this fix on Slackware 15.0.
(This error only happens on Slackware current. Also, on Slackware 15, I would have to add python3-build to vimiv-qt's REQUIRES. python3-build itself has 3 additional dependencies. That would mean 4 extra SlackBuilds total to install.)

I got this idea (for fixing vimiv-qt) from the Alpine Linux repository:
https://gitlab.alpinelinux.org/alpine/aports/-/blob/3.22-stable/community/vimiv-qt/makefile.patch

Other changes:
- Remove SLKCFLAGS and LIBDIRSUFFIX (this is just a formatting change)
- Bump build version number (I am adding a patch this time)