### PR TITLE
development/jupyter_server: Remove python3-overrides dependency

### DIFF
--- a/development/jupyter_server/jupyter_server.info
+++ b/development/jupyter_server/jupyter_server.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/j/jupyter_server/jupyte
 MD5SUM="8812dfd79f6a8a2dcbefb72cff7503c1"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-argon2-cffi jupyter_events jupyter-nbconvert jupyter_server_terminals python3-anyio python3-prometheus_client send2trash python3-overrides python3-websocket-client"
+REQUIRES="python3-argon2-cffi jupyter_events jupyter-nbconvert jupyter_server_terminals python3-anyio python3-prometheus_client send2trash python3-websocket-client"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
jupyter_server 2.17.0 no longer requires python3-overrides (but only if the python version is < 3.12).
Slackware 15.0 has Python 3.9.
Slackware current has Python 3.12.

Therefore, I would like to remove python3-overrides from jupyter_server's list of dependencies (for Slackware current only).

This upstream jupyter_server commit is what dropped the dependency on python3-overrides for python >= 3.12:
https://github.com/jupyter-server/jupyter_server/pull/1532

I updated jupyter_server to 2.17.0 within this pull request to SlackBuilds.org: https://github.com/SlackBuildsOrg/slackbuilds/pull/11949