### PR TITLE
python/python3-async-lru: Remove python3-typing-extensions dependency

### DIFF
--- a/python/python3-async-lru/python3-async-lru.info
+++ b/python/python3-async-lru/python3-async-lru.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/aio-libs/async-lru/releases/download/v2.0.5/async_l
 MD5SUM="c972e8755626506ca019085e0620e192"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-typing-extensions"
+REQUIRES=""
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
python3-async-lru's setup.cfg lists the following:
```
[options]
python_requires = >=3.9
packages = find:
install_requires = 
	typing_extensions>=4.0.0; python_version<"3.11"
```

This means that python3-typing-extensions is only required if Python is at versions 3.10 or lower.
On Slackware 15.0, Python is at version 3.9.
On Slackware current, Python is at version 3.12.

Supporting this: According to the upstream [CHANGES.rst](https://github.com/aio-libs/async-lru/blob/master/CHANGES.rst), python3-async-lru since version 2.0.3 has dropped the python3-typing-extensions dependency for Python >= 3.11.

Therefore, I would like to remove python3-typing-extensions from python3-async-lru's list of dependencies (but only on Slackware-current, not on Slackware 15.)