### PR TITLE
Patch d-feet to make it build with newer versions of meson

### DIFF
--- a/system/d-feet/d-feet.SlackBuild
+++ b/system/d-feet/d-feet.SlackBuild
@@ -73,6 +73,10 @@ cd $TMP
 rm -rf $PRGNAM-$VERSION
 tar xvf $CWD/$PRGNAM-$VERSION.tar.?z*
 cd $PRGNAM-$VERSION
+
+# Make data/meson.build work with a newer version of meson 
+git apply $CWD/data_meson_build.patch
+
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \

--- a/system/d-feet/data_meson_build.patch
+++ b/system/d-feet/data_meson_build.patch
@@ -1,0 +1,20 @@
+diff --git a/data/meson.build b/data/meson.build
+index 026bd80..3b03b94 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -13,7 +13,6 @@ desktop_in = configure_file(
+ )
+ 
+ i18n.merge_file(
+-  desktop,
+   type: 'desktop',
+   input: desktop_in,
+   output: '@BASENAME@',
+@@ -25,7 +24,6 @@ i18n.merge_file(
+ appdata = df_namespace + '.appdata.xml'
+ 
+ i18n.merge_file(
+-  appdata,
+   input: appdata + '.in',
+   output: '@BASENAME@',
+   po_dir: po_dir,


### PR DESCRIPTION
When running the SlackBuild script for d-feet, the configuration ends with the error:

`../data/meson.build:15:5: ERROR: Function does not take positional arguments.`

As far as my understanding goes, there has been a change in the way meson build files should be written, for newer `meson` versions. Following an [example](https://github.com/AravisProject/aravis/commit/a6586e37711bf9aa8d504d5262b9858d33ba96cf) for another program, I am removing two lines from `data/meson.build`, using a patch file. This causes the d-feet package to build normally.