### PR TITLE
libraries/coeurl: patch for meson changes

### DIFF
--- a/libraries/coeurl/coeurl.SlackBuild
+++ b/libraries/coeurl/coeurl.SlackBuild
@@ -84,6 +84,7 @@ find -L . \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
 patch -p1 < $CWD/831e2ee8e9cf08ea1ee9736cde8370f9d0312abc.patch
+patch -p1 < $CWD/patches/curlwrap.patch
 
 mkdir build
 cd build

--- a/libraries/coeurl/patches/curlwrap.patch
+++ b/libraries/coeurl/patches/curlwrap.patch
@@ -1,0 +1,9 @@
+--- a/subprojects/curl.wrap	2025-09-30 23:32:45.714201242 -0400
++++ b/subprojects/curl.wrap	2025-09-30 23:30:38.012198946 -0400
+@@ -5,5 +5,5 @@
+ source_filename = curl-7.77.0.tar.xz
+ source_hash = 0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b
+ 
+-[provides]
++[provide]
+ dependency_names = libcurl


### PR DESCRIPTION
coeurl breaks under recent meson changes due to an error in its curl wrap file. this commit adds a patch for that, since the vendor provides no solution.