### PR TITLE
desktop/xdg-desktop-portal-gtk: Remove gnome-desktop dependency by default

### DIFF
--- a/desktop/xdg-desktop-portal-gtk/README
+++ b/desktop/xdg-desktop-portal-gtk/README
@@ -4,3 +4,6 @@ A backend implementation for xdg-desktop-portal that is using
 GTK+ and various pieces of GNOME infrastructure, such as the
 org.gnome.Shell.Screenshot or org.gnome.SessionManager D-Bus
 interfaces.
+
+To enable the wallpaper portal (gnome-desktop additionally required),
+pass WALLPAPER=yes to the SlackBuild.

--- a/desktop/xdg-desktop-portal-gtk/xdg-desktop-portal-gtk.SlackBuild
+++ b/desktop/xdg-desktop-portal-gtk/xdg-desktop-portal-gtk.SlackBuild
@@ -30,7 +30,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=xdg-desktop-portal-gtk
 VERSION=${VERSION:-1.15.3}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -80,6 +80,9 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \+
 
+# Enable or disable the wallpaper portal
+[ ${WALLPAPER:-no} = yes ] && WALLPAPER_PORTAL=enabled || WALLPAPER_PORTAL=disabled
+
 mkdir build
 cd build
   CFLAGS="$SLKCFLAGS" \
@@ -92,7 +95,8 @@ cd build
     --mandir=/usr/man \
     --prefix=/usr \
     --sysconfdir=/etc \
-    -Dstrip=true
+    -Dstrip=true \
+    -Dwallpaper=$WALLPAPER_PORTAL
   "${NINJA:=ninja}"
   DESTDIR=$PKG $NINJA install
 cd ..

--- a/desktop/xdg-desktop-portal-gtk/xdg-desktop-portal-gtk.info
+++ b/desktop/xdg-desktop-portal-gtk/xdg-desktop-portal-gtk.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://github.com/flatpak/xdg-desktop-portal-gtk/releases/download/1.
 MD5SUM="2d6e2ad2953c386a1db11618fa3803b0"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="gnome-desktop"
+REQUIRES=""
 MAINTAINER="Vincent Batts"
 EMAIL="vbatts@hashbangbash.com"


### PR DESCRIPTION
I found that gnome-desktop is required because `-Dwallpaper=enabled` is set by default.

I could install xdg-desktop-portal-gtk without gnome-desktop if I set `-Dwallpaper=disabled`.

The `-Dwallpaper` meson build option is for building the wallpaper portal.

I don't see a need for building the wallpaper portal if I am using xdg-desktop-portal-gtk outside of GNOME (ex. only as a dependency for flatpak).

This pull request removes the gnome-desktop requirement by default (meaning that the SlackBuild does not build the wallpaper portal by default). However, users can still install the desktop portal by passing `WALLPAPER=yes` to the SlackBuild (this will set `-Dwallpaper=enabled` - in this case then, gnome-desktop will become an additional dependency).

I have also bumped the build version number (I am ensuring that a software feature is optional.)