### PR TITLE
libraries/fuzzylite: Fix cmake compilation errors

### DIFF
--- a/libraries/fuzzylite/fix-catch-glibc-compatibility.patch
+++ b/libraries/fuzzylite/fix-catch-glibc-compatibility.patch
@@ -1,0 +1,30 @@
+diff --git a/fuzzylite/test/catch.hpp b/fuzzylite/test/catch.hpp
+index 6f9334ba..9730e8fe 100644
+--- a/fuzzylite/test/catch.hpp
++++ b/fuzzylite/test/catch.hpp
+@@ -6375,7 +6375,7 @@ namespace Catch {
+         static bool isSet;
+         static struct sigaction oldSigActions [sizeof(signalDefs)/sizeof(SignalDefs)];
+         static stack_t oldSigStack;
+-        static char altStackMem[SIGSTKSZ];
++        static char altStackMem[4000];
+ 
+         static void handleSignal( int sig ) {
+             std::string name = "<unknown signal>";
+@@ -6395,7 +6395,7 @@ namespace Catch {
+             isSet = true;
+             stack_t sigStack;
+             sigStack.ss_sp = altStackMem;
+-            sigStack.ss_size = SIGSTKSZ;
++            sigStack.ss_size = 4000;
+             sigStack.ss_flags = 0;
+             sigaltstack(&sigStack, &oldSigStack);
+             struct sigaction sa = { 0 };
+@@ -6426,7 +6426,7 @@ namespace Catch {
+     bool FatalConditionHandler::isSet = false;
+     struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
+     stack_t FatalConditionHandler::oldSigStack = {};
+-    char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
++    char FatalConditionHandler::altStackMem[4000] = {};
+ 
+ } // namespace Catch

--- a/libraries/fuzzylite/fuzzylite.SlackBuild
+++ b/libraries/fuzzylite/fuzzylite.SlackBuild
@@ -79,11 +79,14 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+patch -p1 < $CWD/fix-catch-glibc-compatibility.patch
+
 cd $PRGNAM && mkdir -p build
 cd build
   cmake \
     -DCMAKE_CXX_FLAGS_RELEASE:STRING="$SLKCFLAGS -Wno-error" \
     -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DCMAKE_BUILD_TYPE=Release ..
   make
   make install DESTDIR=$PKG

--- a/libraries/fuzzylite/patch
+++ b/libraries/fuzzylite/patch
@@ -1,0 +1,57 @@
+diff --git a/libraries/fuzzylite/fix-catch-glibc-compatibility.patch b/libraries/fuzzylite/fix-catch-glibc-compatibility.patch
+new file mode 100644
+index 00000000000..59f57e6c78b
+--- /dev/null
++++ b/libraries/fuzzylite/fix-catch-glibc-compatibility.patch
+@@ -0,0 +1,30 @@
++diff --git a/fuzzylite/test/catch.hpp b/fuzzylite/test/catch.hpp
++index 6f9334ba..9730e8fe 100644
++--- a/fuzzylite/test/catch.hpp
+++++ b/fuzzylite/test/catch.hpp
++@@ -6375,7 +6375,7 @@ namespace Catch {
++         static bool isSet;
++         static struct sigaction oldSigActions [sizeof(signalDefs)/sizeof(SignalDefs)];
++         static stack_t oldSigStack;
++-        static char altStackMem[SIGSTKSZ];
+++        static char altStackMem[4000];
++ 
++         static void handleSignal( int sig ) {
++             std::string name = "<unknown signal>";
++@@ -6395,7 +6395,7 @@ namespace Catch {
++             isSet = true;
++             stack_t sigStack;
++             sigStack.ss_sp = altStackMem;
++-            sigStack.ss_size = SIGSTKSZ;
+++            sigStack.ss_size = 4000;
++             sigStack.ss_flags = 0;
++             sigaltstack(&sigStack, &oldSigStack);
++             struct sigaction sa = { 0 };
++@@ -6426,7 +6426,7 @@ namespace Catch {
++     bool FatalConditionHandler::isSet = false;
++     struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
++     stack_t FatalConditionHandler::oldSigStack = {};
++-    char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+++    char FatalConditionHandler::altStackMem[4000] = {};
++ 
++ } // namespace Catch
+diff --git a/libraries/fuzzylite/fuzzylite.SlackBuild b/libraries/fuzzylite/fuzzylite.SlackBuild
+index f0e6d0ad436..913b70b12b6 100644
+--- a/libraries/fuzzylite/fuzzylite.SlackBuild
++++ b/libraries/fuzzylite/fuzzylite.SlackBuild
+@@ -79,12 +79,15 @@ find -L . \
+  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
+   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+ 
++patch -p1 < $CWD/fix-catch-glibc-compatibility.patch
++
+ cd $PRGNAM && mkdir -p build
+ cd build
+   cmake \
+     -DCMAKE_CXX_FLAGS_RELEASE:STRING="$SLKCFLAGS -Wno-error" \
+     -DCMAKE_INSTALL_PREFIX=/usr \
+-    -DCMAKE_BUILD_TYPE=Release ..
++    -DCMAKE_BUILD_TYPE=Release \
++    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
+   make
+   make install DESTDIR=$PKG
+ cd ../..


### PR DESCRIPTION
I found the following 2 compilation errors:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

```
In file included from /usr/include/signal.h:328,
                 from /tmp/SBo/fuzzylite-6.0/fuzzylite/./test/catch.hpp:6355,
                 from /tmp/SBo/fuzzylite-6.0/fuzzylite/test/MainTest.cpp:19:
/tmp/SBo/fuzzylite-6.0/fuzzylite/./test/catch.hpp:6378:33: error: size of array ‘altStackMem’ is not an integral constant-expression
 6378 |         static char altStackMem[SIGSTKSZ];
      |                                 ^~~~~~~~
/tmp/SBo/fuzzylite-6.0/fuzzylite/./test/catch.hpp:6429:45: error: size of array ‘altStackMem’ is not an integral constant-expression
 6429 |     char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
      |                                             ^~~~~~~~
make[2]: *** [CMakeFiles/fl-test.dir/build.make:79: CMakeFiles/fl-test.dir/test/MainTest.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:227: CMakeFiles/fl-test.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

I am using the patch from Arch Linux's AUR:
https://aur.archlinux.org/cgit/aur.git/tree/fix-catch-glibc-compatibility.patch?h=fuzzylite

These errors only happen on Slackware current, not on Slackware 15.
Please fix them.

I am currently working on getting libminizip updated to 1.3.1: https://github.com/Ponce/slackbuilds/pull/343