### PR TITLE
desktop/cheese: Fix build with gcc14

### DIFF
--- a/desktop/cheese/cheese.SlackBuild
+++ b/desktop/cheese/cheese.SlackBuild
@@ -76,6 +76,10 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
+# Fix gcc14 error
+# https://gitlab.gnome.org/GNOME/cheese/-/merge_requests/70
+sed -i "s/g_object_ref (parent)/GTK_WIDGET (g_object_ref (parent))/g" libcheese/cheese-flash.c
+
 mkdir build
 cd build
   CFLAGS="$SLKCFLAGS" \


### PR DESCRIPTION
I had received the following error on Slackware current (excerpt below):

```
../libcheese/cheese-flash.c: In function ‘cheese_flash_set_property’:
../libcheese/cheese-flash.c:135:22: error: assignment to ‘GtkWidget *’ {aka ‘struct _GtkWidget *’} from incompatible pointer type ‘GObject *’ {aka ‘struct _GObject *’} [-Wincompatible-pointer-types]
  135 |         priv->parent = g_object_ref (parent);
      |                      ^
```

Please merge this pull request (I have included the fix within the PR).