### PR TITLE
academin/galculator: Fix build

### DIFF
--- a/academic/galculator/galculator.SlackBuild
+++ b/academic/galculator/galculator.SlackBuild
@@ -80,7 +80,7 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-CFLAGS="$SLKCFLAGS -fcommon" \
+CFLAGS="$SLKCFLAGS -fcommon -std=gnu17" \
 CXXFLAGS="$SLKCFLAGS" \
 ./autogen.sh \
   --prefix=/usr \


### PR DESCRIPTION
Added flag ```-std=gnu17``` to fix package build

Cheers
Michele
