### PR TITLE
python/python3-pytoolconfig: Remove python3-tomli-opt dependency

### DIFF
--- a/python/python3-pytoolconfig/python3-pytoolconfig.info
+++ b/python/python3-pytoolconfig/python3-pytoolconfig.info
@@ -5,6 +5,6 @@ DOWNLOAD="https://files.pythonhosted.org/packages/source/p/pytoolconfig/pytoolco
 MD5SUM="778a74212a53c2bd3573246587139f10"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
-REQUIRES="python3-pdm-backend python3-tomli-opt"
+REQUIRES="python3-pdm-backend"
 MAINTAINER="Isaac Yu"
 EMAIL="isaacyu@protonmail.com"


### PR DESCRIPTION
python3-tomli-opt is not necessary if Python >= 3.11. Slackware-current has Python 3.12 right now.

Here is the source pyproject.toml for context:
```
dependencies = [
    "tomli>=2.0; python_version < \"3.11\"",
    "packaging>=21.3",
    "typing-extensions; python_version < \"3.8\"",
]
```

I am not updating python3-pytoolconfig to 1.3.1 just yet.
I might do that when the next version of Slackware comes out. 