### PR TITLE
development/Coin: Update Coin.SlackBuild to build with current

### DIFF
--- a/development/Coin/Coin.SlackBuild
+++ b/development/Coin/Coin.SlackBuild
@@ -79,7 +79,7 @@ mkdir -p coin_build
 cd coin_build
   cmake \
     -DCMAKE_C_FLAGS:STRING="$SLKCFLAGS" \
-    -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS" \
+    -DCMAKE_CXX_FLAGS:STRING="$SLKCFLAGS -fpermissive" \
     -Hcoin -G "Unix Makefiles" \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCOIN_BUILD_DOCUMENTATION=ON \


### PR DESCRIPTION
And another case for -fpermissive added to the CXX_FLAGS in this case.