### PR TITLE
graphics/darktable: Patched to build with llvm-21 from current

### DIFF
--- a/graphics/darktable/clang-21.patch
+++ b/graphics/darktable/clang-21.patch
@@ -1,0 +1,13 @@
+diff --git a/data/kernels/CMakeLists.txt b/data/kernels/CMakeLists.txt
+index 2e7fd0b309a7..48771063a3bc 100644
+--- a/data/kernels/CMakeLists.txt
++++ b/data/kernels/CMakeLists.txt
+@@ -15,7 +15,7 @@ macro (testcompile_opencl_kernel IN)
+ 
+   add_custom_command(
+     OUTPUT  ${TOUCH}
+-    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.2 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
++    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.2 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -D__IMAGE_SUPPORT__=1 -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
+     COMMAND ${CMAKE_COMMAND} -E touch ${TOUCH} # will be empty!
+     DEPENDS ${IN}
+     COMMENT "Test-compiling OpenCL program ${KERNAME}"

--- a/graphics/darktable/darktable.SlackBuild
+++ b/graphics/darktable/darktable.SlackBuild
@@ -88,6 +88,9 @@ find -L . \
 # gcc-15 compatibility; cf. 9d7ab0e, c2be549, 44884e3
 patch -p0 < $CWD/gcc-15.patch
 
+# llvm-21 compatibility; cf. https://github.com/darktable-org/darktable/pull/19038
+patch -p1 < $CWD/clang-21.patch
+
 mkdir -p build
 cd build
   cmake \


### PR DESCRIPTION
See https://github.com/darktable-org/darktable/pull/19038