### PR TITLE
system/zim-tools: Patch for later versions of ICU (adapted from libzim).

### DIFF
--- a/system/zim-tools/icu76.patch
+++ b/system/zim-tools/icu76.patch
@@ -1,0 +1,16 @@
+Only in zim-tools-3.6.0-new: .meson.build.un~
+diff -ur zim-tools-3.6.0/meson.build zim-tools-3.6.0-new/meson.build
+--- zim-tools-3.6.0/meson.build	2025-04-17 22:32:19.000000000 +0200
++++ zim-tools-3.6.0-new/meson.build	2026-01-19 13:55:40.860895193 +0100
+@@ -25,7 +25,10 @@
+ find_library_in_compiler = meson.version().version_compare('>=0.31.0')
+ rt_dep = dependency('rt', required:false)
+ docopt_dep = dependency('docopt', static:static_linkage)
+-icu_dep = dependency('icu-i18n', static:static_linkage)
++icu_dep = [
++  dependency('icu-i18n', static:static_linkage),
++  dependency('icu-uc', static:static_linkage)
++]
+ 
+ with_writer = host_machine.system() != 'windows'
+ 

--- a/system/zim-tools/zim-tools.SlackBuild
+++ b/system/zim-tools/zim-tools.SlackBuild
@@ -80,6 +80,8 @@ find -L . \
 # fix libzim >= 9.4.0
 sed -i "/warning_level=1/ s/, 'werror=true'//g" meson.build
 
+patch -p1 < $CWD/icu76.patch
+
 mkdir build
 cd build
   CFLAGS="$SLKCFLAGS" \


### PR DESCRIPTION
This also requires #377, #378 and #379.