### PR TITLE
Update compiler flags and fix Makefile and source code

### DIFF
--- a/games/greed/greed.SlackBuild
+++ b/games/greed/greed.SlackBuild
@@ -57,7 +57,7 @@ elif [ "$ARCH" = "i686" ]; then
   SLKCFLAGS="-O2 -march=i686 -mtune=i686"
   LIBDIRSUFFIX=""
 elif [ "$ARCH" = "x86_64" ]; then
-  SLKCFLAGS="-O2 -fPIC"
+  SLKCFLAGS="-O2 -fPIC -Wno-unused-parameter -Wno-incompatible-pointer-types"
   LIBDIRSUFFIX="64"
 else
   SLKCFLAGS="-O2"
@@ -78,6 +78,11 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+
+sed -i 's/\$(CFLAGS)/\$(CFLAGS) $(SLKCFLAGS)/' Makefile
+sed -i 's/ -O3//' Makefile
+sed -i 's/void (\*osig)()/void (*osig)(int)/' greed.c
+sed -i '/extern char \*getenv(), \*tgetstr();/d' greed.c
 
 make
 

--- a/games/greed/greed.SlackBuild
+++ b/games/greed/greed.SlackBuild
@@ -84,7 +84,7 @@ sed -i 's/ -O3//' Makefile
 sed -i 's/void (\*osig)()/void (*osig)(int)/' greed.c
 sed -i '/extern char \*getenv(), \*tgetstr();/d' greed.c
 
-make
+make SLKCFLAGS="$SLKCFLAGS"
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true

--- a/games/hedgewars/cmake4.patch
+++ b/games/hedgewars/cmake4.patch
@@ -9,20 +9,3 @@ diff -Naur hedgewars-src-1.0.2.orig/CMakeLists.txt hedgewars-src-1.0.2/CMakeList
 +        cmake_policy(SET ${hwpolicy} NEW)
      endif()
  endforeach()
- 
-diff -Naur hedgewars-src-1.0.2.orig/misc/libphyslayer/CMakeLists.txt hedgewars-src-1.0.2/misc/libphyslayer/CMakeLists.txt
---- hedgewars-src-1.0.2.orig/misc/libphyslayer/CMakeLists.txt	2022-09-12 16:27:31.000000000 +0200
-+++ hedgewars-src-1.0.2/misc/libphyslayer/CMakeLists.txt	2025-07-23 14:34:08.847368259 +0200
-@@ -21,12 +21,10 @@
- install(TARGETS physlayer RUNTIME DESTINATION ${target_binary_install_dir}
-                           LIBRARY DESTINATION ${target_library_install_dir}
-                           ARCHIVE DESTINATION ${target_library_install_dir})
--get_target_property(physlayer_fullpath physlayer LOCATION)
- 
- 
- ## added standard variables (FORCE or cmake won't pick 'em)
- set(PHYSLAYER_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE STRING "Physlayer include dir" FORCE)
--set(PHYSLAYER_LIBRARY ${physlayer_fullpath} CACHE STRING "Physlayer library" FORCE)
- 
- if(BUILD_ENGINE_JS)
-     set_target_properties(physlayer PROPERTIES SUFFIX ".bc")


### PR DESCRIPTION
Added additional compiler flags and modified Makefile and source code for compatibility.

```
cc     -DSCOREFILE=\"/usr/games/lib/greed.hs\" -DRELEASE=\"4.2\" -o greed greed.c -lcurses
greed.c: In function ‘quit’:
greed.c:127:22: error: initialization of ‘void (*)(void)’ from incompatible pointer type ‘__sighandler_t’ {aka ‘void (*)(int)’} [-Wincompatible-pointer-types]
  127 |     void (*osig)() = signal(SIGINT, SIG_IGN);   /* save old signal */
      |                      ^~~~~~
In file included from greed.c:54:
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
greed.c:134:35: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
  134 |             (void) signal(SIGINT, osig);        /* reset old signal */
      |                                   ^~~~
      |                                   |
      |                                   void (*)(void)
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
greed.c:135:36: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
  135 |             (void) signal(SIGQUIT, osig);
      |                                    ^~~~
      |                                    |
      |                                    void (*)(void)
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
greed.c: In function ‘topscores’:
greed.c:521:18: error: conflicting types for ‘getenv’; have ‘char *(void)’
  521 |     extern char *getenv(), *tgetstr();
      |                  ^~~~~~
In file included from greed.c:48:
/usr/include/stdlib.h:773:14: note: previous declaration of ‘getenv’ with type ‘char *(const char *)’
  773 | extern char *getenv (const char *__name) __THROW __nonnull ((1)) __wur;
      |              ^~~~~~
greed.c:521:29: error: conflicting types for ‘tgetstr’; have ‘char *(void)’
  521 |     extern char *getenv(), *tgetstr();
      |                             ^~~~~~~
In file included from greed.c:53:
/usr/include/term.h:845:31: note: previous declaration of ‘tgetstr’ with type ‘char *(const char *, char **)’
  845 | extern NCURSES_EXPORT(char *) tgetstr (const char *, char **);
      |                               ^~~~~~~
greed.c:576:33: error: too many arguments to function ‘getenv’; expected 0, have 1
  576 |     if (new && tgetent(termbuf, getenv("TERM")) > 0) {
      |                                 ^~~~~~ ~~~~~~
greed.c:521:18: note: declared here
  521 |     extern char *getenv(), *tgetstr();
      |                  ^~~~~~
greed.c:578:18: error: too many arguments to function ‘tgetstr’; expected 0, have 2
  578 |         boldon = tgetstr("so", &tptr);
      |                  ^~~~~~~ ~~~~
greed.c:521:29: note: declared here
  521 |     extern char *getenv(), *tgetstr();
      |                             ^~~~~~~
greed.c:579:19: error: too many arguments to function ‘tgetstr’; expected 0, have 2
  579 |         boldoff = tgetstr("se", &tptr);
      |                   ^~~~~~~ ~~~~
greed.c:521:29: note: declared here
  521 |     extern char *getenv(), *tgetstr();
      |                             ^~~~~~~
make: *** [Makefile:10: greed] Error 1
```